### PR TITLE
Decode xhtml to deal with character entities

### DIFF
--- a/RichTextBlockProperties.cs
+++ b/RichTextBlockProperties.cs
@@ -65,6 +65,9 @@ namespace html2xaml
             string xhtml = string.Format("<div>{0}</div>", e.NewValue as string);
 
             xhtml = xhtml.Replace("\r", "").Replace("\n", "<br />");
+            //Decode the xhtml to take care of special character entity references e.g. &copy; &euro;
+            //which are not supported by Xml.
+            xhtml = System.Net.WebUtility.HtmlDecode(xhtml);
             RichTextBlock newRichText = null;
             if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
             {


### PR DESCRIPTION
Hi, I was using the project and noticed that loadXml in ConvertHtmlToXamlRichTextBlock would throw an exception if the Html contained character entity references like &euro ; or &auml ; or others. 
I tried to fix it by decoding the xhtml before calling loadXml and it works. 
So I created this pull request. I hope it helps.
